### PR TITLE
lib/service/iservice.h - fixed : In member function ‘virtual PyObject…

### DIFF
--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -429,7 +429,7 @@ public:
 	virtual ePtr<iServiceInfoContainer> getInfoObject(int w);
 	virtual ePtr<iDVBTransponderData> getTransponderData();
 	virtual void getAITApplications(std::map<int, std::string> &aitlist) {};
-	virtual PyObject *getHbbTVApplications() {};
+	virtual PyObject *getHbbTVApplications() {return getHbbTVApplications();};
 	virtual void getCaIds(std::vector<int> &caids, std::vector<int> &ecmpids, std::vector<std::string> &ecmdatabytes);
 	virtual long long getFileSize();
 


### PR DESCRIPTION
……  …* iServiceInformation::getHbbTVApplications()’:  ../lib/service/iservice.h:445:44: warning: no return statement in function returning non-void [-Wreturn-type]   445 |  virtual PyObject *getHbbTVApplications() {};       |                                            ^