### PR TITLE
lib/dvb/pmt.h:54:14: fixed warning: ‘HbbTVApplicationInfo::m_Applicat…

### DIFF
--- a/lib/dvb/pmt.h
+++ b/lib/dvb/pmt.h
@@ -54,8 +54,8 @@ public:
 	short m_ProfileCode;
 public:
 	HbbTVApplicationInfo(int controlCode, int orgid, int appid, std::string hbbtvUrl, std::string applicationName,int profileCode)
-		: m_ControlCode(controlCode), m_OrgId(orgid), m_AppId(appid), m_HbbTVUrl(hbbtvUrl), m_ApplicationName(applicationName),
-		m_ProfileCode(profileCode)
+		: m_OrgId(orgid), m_AppId(appid), m_ControlCode(controlCode), m_ProfileCode(profileCode),
+		m_HbbTVUrl(hbbtvUrl), m_ApplicationName(applicationName)
 	{}
 };
 typedef std::list<HbbTVApplicationInfo *> HbbTVApplicationInfoList;


### PR DESCRIPTION
……  …ionName’ will be initialized after [-Wreorder]     54 |  std::string m_ApplicationName;       |              ^~~~~~~~~~~~~~~~~ ../lib/dvb/pmt.h:49:6: warning:   ‘int HbbTVApplicationInfo::m_OrgId’ [-Wreorder]    49 |  int m_OrgId;       |      ^~~~~~~ ../lib/dvb/pmt.h:56:2: warning:   when initialized here [-Wreorder]    56 |  HbbTVApplicationInfo(int controlCode, int orgid, int appid, std::string hbbtvUrl, std::string applicationName,int profileCode)       |  ^~~~~~~~~~~~~~~~~~~~